### PR TITLE
session过期后跳转到登录页

### DIFF
--- a/vuehr/src/utils/api.js
+++ b/vuehr/src/utils/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import {Message} from 'element-ui'
+import router from '@/router'
 axios.interceptors.request.use(config => {
   return config;
 }, err => {
@@ -20,6 +21,7 @@ axios.interceptors.response.use(data => {
     Message.error({message: '服务器被吃了⊙﹏⊙∥'});
   } else if (err.response.status == 403) {
     Message.error({message: '权限不足,请联系管理员!'});
+    router.push("/")
   } else if (err.response.status == 401) {
     Message.error({message: err.response.data.msg});
   } else {


### PR DESCRIPTION
登录系统session过期后，刷新页面没啥反应，其实后台已经返回403了
你原来的逻辑403表示未认证，触发到这个分支一般是用户手动输入url想要跳转到某个菜单，此时用户没有权限跳转到登录页其实也OK