### PR TITLE
修复“当变更用户权限组，权限信息未即时生效”的问题

### DIFF
--- a/vhr/vhrserver/vhr-web/src/main/java/org/javaboy/vhr/controller/system/basic/PermissController.java
+++ b/vhr/vhrserver/vhr-web/src/main/java/org/javaboy/vhr/controller/system/basic/PermissController.java
@@ -41,6 +41,7 @@ public class PermissController {
     }
 
     @PutMapping("/")
+    @CacheEvict(value = "menuService", allEntries = true)
     public RespBean updateMenuRole(Integer rid, Integer[] mids) {
         if (menuService.updateMenuRole(rid, mids)) {
             return RespBean.ok("更新成功!");
@@ -49,6 +50,7 @@ public class PermissController {
     }
 
     @PostMapping("/role")
+    @CacheEvict(value = "menuService", allEntries = true)
     public RespBean addRole(@RequestBody Role role) {
         if (roleService.addRole(role) == 1) {
             return RespBean.ok("添加成功!");
@@ -57,6 +59,7 @@ public class PermissController {
     }
 
     @DeleteMapping("/role/{rid}")
+    @CacheEvict(value = "menuService", allEntries = true)
     public RespBean deleteRoleById(@PathVariable Integer rid) {
         if (roleService.deleteRoleById(rid) == 1) {
             return RespBean.ok("删除成功!");


### PR DESCRIPTION
修改用户的权限组后，清除Redis的权限缓存即可使得下一次请求得到的权限信息是最新的。