### PR TITLE
rabbitmq的配置的ConfirmCallback方法不执行，邮件发送成功后status仍为1

### DIFF
--- a/vhr/vhrserver/vhr-web/src/main/resources/application.yml
+++ b/vhr/vhrserver/vhr-web/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     username: guest
     password: guest
     host: 127.0.0.1
-    publisher-confirms: true
+    publisher-confirm-type: correlated
     publisher-returns: true
   redis:
     host: 127.0.0.1


### PR DESCRIPTION
将原publisher-confirms修改为publisher-confirm-type: correlated，新版中原属性已弃用，因此设置失效
新版本publisher-confirms已经修改为publisher-confirm-type，其默认为NONE，即不进行确认，如果需要ack后进行回调确认，配置为correlated。