### PR TITLE
master

### DIFF
--- a/vhr/mailserver/pom.xml
+++ b/vhr/mailserver/pom.xml
@@ -7,7 +7,6 @@
         <groupId>org.javaboy</groupId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.javaboy</groupId>
     <artifactId>mailserver</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>mailserver</name>


### PR DESCRIPTION
Definition of groupId is redundant, because it's inherited from the parent 